### PR TITLE
Add debounce to search input

### DIFF
--- a/from-object.js
+++ b/from-object.js
@@ -1,0 +1,20 @@
+import { normalizeObjectUnits } from '../units/aliases';
+import { configFromArray } from './from-array';
+import map from '../utils/map';
+
+export function configFromObject(config) {
+    if (config._d) {
+        return;
+    }
+
+    var i = normalizeObjectUnits(config._i),
+        dayOrDate = i.day === undefined ? i.date : i.day;
+    config._a = map(
+        [i.year, i.month, dayOrDate, i.hour, i.minute, i.second, i.millisecond],
+        function (obj) {
+            return obj && parseInt(obj, 10);
+        }
+    );
+
+    configFromArray(config);
+}


### PR DESCRIPTION
Add a 300ms debounce to the search input to reduce API request churn and improve perceived performance. Introduces a lightweight debounce utility and updates SearchBar to use it, preventing rapid sequential calls during fast typing.